### PR TITLE
MAX40080: fix a bug in read_register which causes unintentional fifo reads

### DIFF
--- a/src/MAX40080/MAX40080.cpp
+++ b/src/MAX40080/MAX40080.cpp
@@ -111,7 +111,7 @@ int MAX40080::read_register(uint8_t reg, uint8_t *buf, uint8_t len/*=1*/)
         r_Len += 1; // +1 for PEC byte
     }
 
-    m_i2c->requestFrom((char)m_slave_addr, (char)r_Len);
+    m_i2c->requestFrom((char)m_slave_addr, (char)r_Len, true);
 
     while (m_i2c->available()) { // slave may send less than requested
         buf[counter++] = m_i2c->read(); // receive a byte as character

--- a/src/MAX40080/MAX40080.cpp
+++ b/src/MAX40080/MAX40080.cpp
@@ -111,13 +111,11 @@ int MAX40080::read_register(uint8_t reg, uint8_t *buf, uint8_t len/*=1*/)
         r_Len += 1; // +1 for PEC byte
     }
 
-    m_i2c->requestFrom((char)m_slave_addr, (char)r_Len, false);
+    m_i2c->requestFrom((char)m_slave_addr, (char)r_Len);
 
     while (m_i2c->available()) { // slave may send less than requested
         buf[counter++] = m_i2c->read(); // receive a byte as character
     }
-    
-    m_i2c->endTransmission();
 
     //
     if (counter == r_Len) {


### PR DESCRIPTION
`m_i2c->endTransmission();` is causing 2 fifo reads instead of one. ContinuousMode example works as expected after removing that line:

![resim](https://user-images.githubusercontent.com/77487375/149134960-2facd1e2-026a-40a0-9dc9-6808b8265984.png)
